### PR TITLE
Bugfix for list_devices_fs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.1] - 2021-03-13
+### Fixed
+- Fixed `list_devices_fs` returning an `Err` when FTDI devices with invalid
+  EEPROMs are plugged in.
+
 ## [0.25.0] - 2021-02-28
 ### Changed
-- Updated `libftd2xx-ffi` dependency from 0.5.1 to 0.6.0.  This updates the vendor library from 1.4.8 to 1.4.22 for Linux targets.
+- Updated `libftd2xx-ffi` dependency from 0.5.1 to 0.6.0.
+  This updates the vendor library from 1.4.8 to 1.4.22 for Linux targets.
 
 ## [0.24.1] - 2021-01-30
 ### Changed
@@ -76,7 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Prior releases
 A changelog was not kept for prior releases.
 
-[Unreleased]: https://github.com/newAM/libftd2xx-rs/compare/0.25.0...HEAD
+[Unreleased]: https://github.com/newAM/libftd2xx-rs/compare/0.25.1...HEAD
+[0.25.1]: https://github.com/newAM/libftd2xx-rs/compare/0.25.0...0.25.1
 [0.25.0]: https://github.com/newAM/libftd2xx-rs/compare/0.24.1...0.25.0
 [0.24.1]: https://github.com/newAM/libftd2xx-rs/compare/0.24.0...0.24.1
 [0.24.0]: https://github.com/newAM/libftd2xx-rs/compare/0.23.0...0.24.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libftd2xx"
-version = "0.25.0" # remember to update html_root_url
+version = "0.25.1" # remember to update html_root_url
 authors = ["Alex M. <alexmgit@protonmail.com>"]
 edition = "2018"
 description = "Rust safe wrapper around the libftd2xx-ffi crate."

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ permission from FTDI.
 
 ```toml
 [dependencies]
-libftd2xx = "~0.25.0"
+libftd2xx = "~0.25.1"
 ```
 
 This is a basic example to get your started.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! libftd2xx = "~0.25.0"
+//! libftd2xx = "~0.25.1"
 //! ```
 //!
 //! This is a basic example to get your started.
@@ -70,7 +70,7 @@
 //! [setup executable]: https://www.ftdichip.com/Drivers/CDM/CDM21228_Setup.zip
 //! [udev]: https://en.wikipedia.org/wiki/Udev
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/libftd2xx/0.25.0")]
+#![doc(html_root_url = "https://docs.rs/libftd2xx/0.25.1")]
 #![deny(missing_docs)]
 
 mod errors;
@@ -366,9 +366,12 @@ pub fn list_devices_fs() -> io::Result<Vec<DeviceInfo>> {
                 continue;
             }
 
-            let mut product_path = path.clone();
-            product_path.push("idProduct");
-            let pid: String = fs::read_to_string(product_path)?;
+            let mut id_product_path = path.clone();
+            id_product_path.push("idProduct");
+            if !id_product_path.exists() {
+                continue;
+            }
+            let pid: String = fs::read_to_string(id_product_path)?;
             let pid: u16 = u16::from_str_radix(pid.trim(), 16)
                 .expect("idProduct file contains non-hex digits");
 
@@ -380,6 +383,9 @@ pub fn list_devices_fs() -> io::Result<Vec<DeviceInfo>> {
             let serial: String = {
                 let mut serial_path = path.clone();
                 serial_path.push("serial");
+                if !serial_path.exists() {
+                    continue;
+                }
                 let mut data: String = fs::read_to_string(serial_path)?;
                 let ch = data.pop(); // remove newline
                 debug_assert_eq!(ch, Some('\n'));
@@ -389,6 +395,9 @@ pub fn list_devices_fs() -> io::Result<Vec<DeviceInfo>> {
             let description: String = {
                 let mut product_path = path.clone();
                 product_path.push("product");
+                if !product_path.exists() {
+                    continue;
+                }
                 let mut data: String = fs::read_to_string(product_path)?;
                 let ch = data.pop(); // remove newline
                 debug_assert_eq!(ch, Some('\n'));


### PR DESCRIPTION
Fixed a conditon where list_devices_fs would return an Err value for FTDI devices with invalid EEPROMs.