### PR TITLE
Gracefully handle FT_OTHER_ERROR for FT_GetDeviceInfo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,8 +132,8 @@ use libftd2xx_ffi::{
     FT_SetFlowControl, FT_SetLatencyTimer, FT_SetRts, FT_SetTimeouts, FT_SetUSBParameters,
     FT_Write, FT_WriteEE, FT_DEVICE_LIST_INFO_NODE, FT_EEPROM_2232H, FT_EEPROM_232H,
     FT_EEPROM_4232H, FT_FLOW_DTR_DSR, FT_FLOW_NONE, FT_FLOW_RTS_CTS, FT_FLOW_XON_XOFF, FT_HANDLE,
-    FT_LIST_NUMBER_ONLY, FT_OK, FT_OPEN_BY_DESCRIPTION, FT_OPEN_BY_SERIAL_NUMBER, FT_OTHER_ERROR,
-    FT_PURGE_RX, FT_PURGE_TX, FT_STATUS,
+    FT_LIST_NUMBER_ONLY, FT_OPEN_BY_DESCRIPTION, FT_OPEN_BY_SERIAL_NUMBER, FT_PURGE_RX,
+    FT_PURGE_TX, FT_STATUS,
 };
 
 #[cfg(target_os = "windows")]
@@ -574,6 +574,52 @@ pub trait FtdiCommon {
     /// Get the FTDI device handle.
     fn handle(&mut self) -> FT_HANDLE;
 
+    /// Identify device type.
+    ///
+    /// This will attempt to identify the device using the the [`device_info`]
+    /// method, if that method fails it will then try to determine the device type
+    /// from the value stored in the EEPROM.
+    /// If the EEPROM value does not match a known device this function returns
+    /// [`FtStatus::OTHER_ERROR`], though there may be other conditions in the
+    /// vendor driver that also return this code.
+    ///
+    /// This is not a native function in `libftd2xx`, this works around a bug in
+    /// `libftd2xx`, see https://github.com/newAM/libftd2xx-rs/pull/37 for more
+    /// information.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use libftd2xx::{Ftdi, FtdiCommon};
+    ///
+    /// let mut ft = Ftdi::new()?;
+    /// let dev_type = ft.device_type()?;
+    /// println!("Device type: {:?}", dev_type);
+    /// # Ok::<(), libftd2xx::FtStatus>(())
+    /// ```
+    fn device_type(&mut self) -> Result<DeviceType, FtStatus> {
+        if let Ok(info) = self.device_info() {
+            Ok(info.device_type)
+        } else {
+            match self.eeprom_word_read(0x3)? {
+                0x0200 => Ok(DeviceType::FTAM),
+                0x0400 => Ok(DeviceType::FTBM),
+                // ??? => Ok(DeviceType::FT100AX),
+                0x0500 => Ok(DeviceType::FT2232C),
+                0x0600 => Ok(DeviceType::FT232R),
+                0x0700 => Ok(DeviceType::FT2232H),
+                0x0800 => Ok(DeviceType::FT4232H),
+                0x0900 => Ok(DeviceType::FT232H),
+                0x1000 => Ok(DeviceType::FT_X_SERIES),
+                0x1700 => Ok(DeviceType::FT4222H_3),
+                0x1800 => Ok(DeviceType::FT4222H_0),
+                0x1900 => Ok(DeviceType::FT4222H_1_2),
+                0x2100 => Ok(DeviceType::FT4222_PROG),
+                _ => Err(FtStatus::OTHER_ERROR),
+            }
+        }
+    }
+
     /// Get device information for an open device.
     ///
     /// # Example
@@ -613,19 +659,10 @@ pub trait FtdiCommon {
                 device_type: device_type.into(),
                 product_id: pid,
                 vendor_id: vid,
-                serial_number: match status {
-                    FT_OK => slice_into_string(serial_number.as_ref()),
-                    _ => String::default(),
-                },
-                description: match status {
-                    FT_OK => slice_into_string(description.as_ref()),
-                    _ => String::default(),
-                },
+                serial_number: slice_into_string(serial_number.as_ref()),
+                description: slice_into_string(description.as_ref()),
             },
-            match status {
-                FT_OTHER_ERROR => FT_OK,
-                n => n,
-            },
+            status,
         )
     }
 
@@ -2182,6 +2219,14 @@ impl Ft4232h {
     }
 }
 
+impl FtdiCommon for Ftdi {
+    const DEVICE_TYPE: DeviceType = DeviceType::Unknown;
+
+    fn handle(&mut self) -> FT_HANDLE {
+        self.handle
+    }
+}
+
 macro_rules! impl_boilerplate_for {
     ($DEVICE:ident, $TYPE:expr) => {
         impl FtdiCommon for $DEVICE {
@@ -2189,6 +2234,10 @@ macro_rules! impl_boilerplate_for {
 
             fn handle(&mut self) -> FT_HANDLE {
                 self.handle
+            }
+
+            fn device_type(&mut self) -> Result<DeviceType, FtStatus> {
+                Ok(Self::DEVICE_TYPE)
             }
         }
     };
@@ -2200,7 +2249,7 @@ macro_rules! impl_try_from_for {
             type Error = DeviceTypeError;
 
             fn try_from(mut ft: Ftdi) -> Result<Self, Self::Error> {
-                let device_type: DeviceType = ft.device_info()?.device_type;
+                let device_type: DeviceType = ft.device_type()?;
                 if device_type != Self::DEVICE_TYPE {
                     Err(DeviceTypeError::DeviceType {
                         expected: $DEVICE::DEVICE_TYPE,
@@ -2216,7 +2265,6 @@ macro_rules! impl_try_from_for {
     };
 }
 
-impl_boilerplate_for!(Ftdi, DeviceType::Unknown);
 impl_boilerplate_for!(Ft232h, DeviceType::FT232H);
 impl_boilerplate_for!(Ft2232h, DeviceType::FT2232H);
 impl_boilerplate_for!(Ft4232h, DeviceType::FT4232H);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -597,6 +597,8 @@ pub trait FtdiCommon {
     /// println!("Device type: {:?}", dev_type);
     /// # Ok::<(), libftd2xx::FtStatus>(())
     /// ```
+    ///
+    /// [`device_info`]: crate::FtdiCommon::device_info
     fn device_type(&mut self) -> Result<DeviceType, FtStatus> {
         if let Ok(info) = self.device_info() {
             Ok(info.device_type)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -649,9 +649,6 @@ pub trait FtdiCommon {
             )
         };
         let (vid, pid) = vid_pid_from_id(device_id);
-        // If the device is not fitted with a configured EEPROM, FT_GetDeviceInfo returns
-        // FT_OTHER_ERROR. In this case, all returned values except for serial_number and
-        // description are valid.
         ft_result(
             DeviceInfo {
                 port_open: true,

--- a/src/types.rs
+++ b/src/types.rs
@@ -598,11 +598,15 @@ pub struct DeviceInfo {
     ///
     /// This is assumed to be UTF-8.
     /// Data that is not UTF-8 will appear as the replacement character �.
+    ///
+    /// If device is not fitted with a configured EEPROM, this will be empty.
     pub serial_number: String,
     /// Device description.
     ///
     /// This is assumed to be UTF-8.
     /// Data that is not UTF-8 will appear as the replacement character �.
+    ///
+    /// If device is not fitted with a configured EEPROM, this will be empty.
     pub description: String,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -598,15 +598,11 @@ pub struct DeviceInfo {
     ///
     /// This is assumed to be UTF-8.
     /// Data that is not UTF-8 will appear as the replacement character �.
-    ///
-    /// If device is not fitted with a configured EEPROM, this will be empty.
     pub serial_number: String,
     /// Device description.
     ///
     /// This is assumed to be UTF-8.
     /// Data that is not UTF-8 will appear as the replacement character �.
-    ///
-    /// If device is not fitted with a configured EEPROM, this will be empty.
     pub description: String,
 }
 


### PR DESCRIPTION
For devices that do not have a configured EEPROM attached, there are no USB string descriptors present. Under this condition, `FT_GetDeviceInfo` will return `FT_OTHER_ERROR`. This is the case for an Adafruit FT232H module with factory configuration and libftd2xx 1.4.24 (current x86_64 Linux release at time of writing).

Static analysis of this function indicates that all fields except `serial_number` and `description` are valid for `FT_OTHER_ERROR`. These string parameters are unmodified in this case.

This really seems to be a bug in FTDI's implementation. It also causes internal misbehaviors that affect the output of `FT_GetDeviceInfoList` (all zero fields).