### PR TITLE
Use rust paths for doc links instead of HTML locations

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,8 +20,8 @@ use libftd2xx_ffi::{
 ///
 /// This is used by the [`read_all`] and [`write_all`] methods.
 ///
-/// [`read_all`]: trait.FtdiCommon.html#method.read_all
-/// [`write_all`]: trait.FtdiCommon.html#method.read_all
+/// [`read_all`]: crate::FtdiCommon::read_all
+/// [`write_all`]: crate::FtdiCommon::write_all
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum TimeoutError {
     /// FTDI status errors.
@@ -164,9 +164,6 @@ const DEVICE_LIST_NOT_READY: FT_STATUS = FT_DEVICE_LIST_NOT_READY as FT_STATUS;
 ///
 /// This is also used in the [`TimeoutError`], and [`DeviceTypeError`]
 /// enumerations.
-///
-/// [`DeviceTypeError`]: ./enum.DeviceTypeError.html
-/// [`TimeoutError`]: ./enum.TimeoutError.html
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[allow(non_camel_case_types, missing_docs)]
 #[repr(u32)]
@@ -248,11 +245,11 @@ fn ft_status_display() {
 /// Some EEPROM values, such as the [`DriveCurrent`] have a fixed range of valid
 /// values.  However, the EEPROM may not be programmed with valid values.
 ///
-/// [`Cbus232h`]: ./enum.Cbus232h.html
-/// [`Cbus232r`]: ./enum.Cbus232r.html
-/// [`CbusX`]: ./enum.CbusX.html
-/// [`DriveCurrent`]: ./enum.DriveCurrent.html
-/// [`DriverType`]: ./enum.DriverType.html
+/// [`Cbus232h`]: crate::Cbus232h
+/// [`Cbus232r`]: crate::Cbus232r
+/// [`CbusX`]: crate::CbusX
+/// [`DriveCurrent`]: crate::DriveCurrent
+/// [`DriverType`]: crate::DriverType
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct EepromValueError {
     /// Invalid value.
@@ -288,9 +285,9 @@ fn drive_current_error_display() {
 
 /// EEPROM strings error.
 ///
-/// This error is used by `set_manufacturer`, `set_manufacturer_id`,
-/// `set_description`, and `set_serial_number` methods on EEPROM structures when
-/// the length of these strings exceeds the maximums.
+/// This error is used by [`set_manufacturer`], [`set_manufacturer_id`],
+/// [`set_description`], and [`set_serial_number`] methods on EEPROM
+/// structures when the length of these strings exceeds the maximums.
 ///
 /// There are two limits to these strings:
 ///
@@ -298,6 +295,11 @@ fn drive_current_error_display() {
 /// * The total length of the `manufacturer`, `manufacturer_id`,
 ///   `description`, and `serial_number` strings can not exceed
 ///   96 characters.
+///
+/// [`set_manufacturer`]: crate::EepromStrings::set_manufacturer
+/// [`set_manufacturer_id`]: crate::EepromStrings::set_manufacturer_id
+/// [`set_description`]: crate::EepromStrings::set_description
+/// [`set_serial_number`]: crate::EepromStrings::set_serial_number
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub struct EepromStringsError {
     /// Manufacturer string length.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,8 +242,6 @@ pub fn set_vid_pid(vid: u16, pid: u16) -> Result<(), FtStatus> {
 /// println!("PID: 0x{:04X}", vid);
 /// # Ok::<(), libftd2xx::FtStatus>(())
 /// ```
-///
-/// [`set_vid_pid`]: ./fn.set_vid_pid.html
 #[cfg(any(unix, doc))]
 #[cfg_attr(docsrs, doc(cfg(unix)))]
 pub fn vid_pid() -> Result<(u32, u32), FtStatus> {
@@ -584,7 +582,7 @@ pub trait FtdiCommon {
     /// vendor driver that also return this code.
     ///
     /// This is not a native function in `libftd2xx`, this works around a bug in
-    /// `libftd2xx`, see https://github.com/newAM/libftd2xx-rs/pull/37 for more
+    /// `libftd2xx`, see <https://github.com/newAM/libftd2xx-rs/pull/37> for more
     /// information.
     ///
     /// # Example
@@ -724,7 +722,7 @@ pub trait FtdiCommon {
     /// # Ok::<(), libftd2xx::FtStatus>(())
     /// ```
     ///
-    /// [`set_usb_parameters`]: #method.set_usb_parameters
+    /// [`set_usb_parameters`]: FtdiCommon::set_usb_parameters
     fn set_usb_parameters(&mut self, in_transfer_size: u32) -> Result<(), FtStatus> {
         const MAX: u32 = 64 * 1024;
         const MIN: u32 = 64;
@@ -1186,7 +1184,6 @@ pub trait FtdiCommon {
     /// [Bit Mode Functions for the FT2232]: https://www.ftdichip.com/Support/Documents/AppNotes/AN2232C-02_FT2232CBitMode.pdf
     /// [FT232B/FT245B Bit Bang Mode]: https://www.ftdichip.com/Support/Documents/AppNotes/AN232B-01_BitBang.pdf
     /// [FTDI website]: https://www.ftdichip.com/Support/Documents/AppNotes.htm
-    /// [`BitMode`]: ./enum.BitMode.html
     ///
     /// # Example
     ///
@@ -1225,8 +1222,7 @@ pub trait FtdiCommon {
     /// # Ok::<(), libftd2xx::FtStatus>(())
     /// ```
     ///
-    /// [`set_bit_mode`]: #method.set_bit_mode
-    /// [`BitMode`]: ./enum.BitMode.html
+    /// [`set_bit_mode`]: FtdiCommon::set_bit_mode
     fn bit_mode(&mut self) -> Result<u8, FtStatus> {
         let mut mode: u8 = 0;
         trace!("FT_GetBitMode({:?}, _)", self.handle());
@@ -1348,7 +1344,7 @@ pub trait FtdiCommon {
     /// # Ok::<(), libftd2xx::FtStatus>(())
     /// ```
     ///
-    /// [`read_all`]: #method.read_all
+    /// [`read_all`]: FtdiCommon::read_all
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, FtStatus> {
         let mut bytes_returned: u32 = 0;
         let len: u32 = u32::try_from(buf.len()).unwrap();
@@ -1426,10 +1422,10 @@ pub trait FtdiCommon {
     /// # Ok::<(), libftd2xx::TimeoutError>(())
     /// ```
     ///
-    /// [`read_all`]: #method.read_all
-    /// [`queue_status`]: #method.queue_status
-    /// [`set_timeouts`]: #method.set_timeouts
-    /// [`TimeoutError`]: ./enum.TimeoutError.html
+    /// [`read_all`]: FtdiCommon::read_all
+    /// [`queue_status`]: FtdiCommon::queue_status
+    /// [`set_timeouts`]: FtdiCommon::set_timeouts
+    /// [`TimeoutError`]: TimeoutError
     fn read_all(&mut self, buf: &mut [u8]) -> Result<(), TimeoutError> {
         let num_read = self.read(buf)?;
         if num_read != buf.len() {
@@ -1814,7 +1810,7 @@ pub trait FtdiCommon {
     /// # Ok::<(), libftd2xx::FtStatus>(())
     /// ```
     ///
-    /// [`eeprom_user_size`]: #method.eeprom_user_size
+    /// [`eeprom_user_size`]: FtdiCommon::eeprom_user_size
     fn eeprom_user_read(&mut self, buf: &mut [u8]) -> Result<usize, FtStatus> {
         let mut num_read: u32 = 0;
         let len: u32 = u32::try_from(buf.len()).unwrap();
@@ -1841,7 +1837,7 @@ pub trait FtdiCommon {
     /// # Ok::<(), libftd2xx::FtStatus>(())
     /// ```
     ///
-    /// [`eeprom_user_size`]: #method.eeprom_user_size
+    /// [`eeprom_user_size`]: FtdiCommon::eeprom_user_size
     fn eeprom_user_write(&mut self, buf: &[u8]) -> Result<(), FtStatus> {
         let len: u32 = u32::try_from(buf.len()).unwrap();
         trace!("FT_EE_UAWrite({:?}, _, {})", self.handle(), len);
@@ -2001,8 +1997,8 @@ impl Ftdi {
     /// # Ok::<(), libftd2xx::FtStatus>(())
     /// ```
     ///
-    /// [`with_index`]: #method.with_index
-    /// [`with_serial_number`]: #method.with_serial_number
+    /// [`with_index`]: Ftdi::with_index
+    /// [`with_serial_number`]: Ftdi::with_serial_number
     pub fn new() -> Result<Ftdi, FtStatus> {
         Ftdi::with_index(0)
     }
@@ -2026,7 +2022,7 @@ impl Ftdi {
     /// # Ok::<(), libftd2xx::FtStatus>(())
     /// ```
     ///
-    /// [`with_serial_number`]: #method.with_serial_number
+    /// [`with_serial_number`]: Ftdi::with_serial_number
     pub fn with_index(index: i32) -> Result<Ftdi, FtStatus> {
         let mut handle: FT_HANDLE = std::ptr::null_mut();
         trace!("FT_Open({}, _)", index);

--- a/src/mpsse.rs
+++ b/src/mpsse.rs
@@ -28,7 +28,7 @@ enum MpsseCmd {
 ///
 /// This is an argument to the [`clock_data_out`] method.
 ///
-/// [`clock_data_out`]: ./struct.MpsseCmdBuilder.html#method.clock_data_out
+/// [`clock_data_out`]: MpsseCmdBuilder::clock_data_out
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ClockDataOut {
@@ -68,7 +68,7 @@ impl From<ClockDataOut> for u8 {
 ///
 /// This is an argument to the [`clock_bits_out`] method.
 ///
-/// [`clock_bits_out`]: ./struct.MpsseCmdBuilder.html#method.clock_bits_out
+/// [`clock_bits_out`]: MpsseCmdBuilder::clock_bits_out
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ClockBitsOut {
@@ -108,7 +108,7 @@ impl From<ClockBitsOut> for u8 {
 ///
 /// This is an argument to the [`clock_data_in`] method.
 ///
-/// [`clock_data_in`]: ./struct.MpsseCmdBuilder.html#method.clock_data_in
+/// [`clock_data_in`]: MpsseCmdBuilder::clock_data_in
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ClockDataIn {
@@ -148,7 +148,7 @@ impl From<ClockDataIn> for u8 {
 ///
 /// This is an argument to the [`clock_bits_in`] method.
 ///
-/// [`clock_bits_in`]: ./struct.MpsseCmdBuilder.html#method.clock_bits_in
+/// [`clock_bits_in`]: MpsseCmdBuilder::clock_bits_in
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ClockBitsIn {
@@ -200,7 +200,7 @@ impl From<ClockBitsIn> for u8 {
 ///
 /// This is an argument to the [`clock_data`] method.
 ///
-/// [`clock_data`]: ./struct.MpsseCmdBuilder.html#method.clock_data
+/// [`clock_data`]: MpsseCmdBuilder::clock_data
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ClockData {
@@ -224,7 +224,7 @@ impl From<ClockData> for u8 {
 ///
 /// This is an argument to the [`clock_bits`] method.
 ///
-/// [`clock_bits`]: ./struct.MpsseCmdBuilder.html#method.clock_bits
+/// [`clock_bits`]: MpsseCmdBuilder::clock_bits
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ClockBits {
@@ -356,40 +356,40 @@ mod clock_divisor {
 ///
 /// Used by [`initialize_mpsse`].
 ///
-/// [`initialize_mpsse`]: ./trait.FtdiMpsse.html#method.initialize_mpsse
+/// [`initialize_mpsse`]: FtdiMpsse::initialize_mpsse
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct MpsseSettings {
     /// Reset the MPSSE on initialization.
     ///
     /// This calls [`reset`] if `true`.
     ///
-    /// [`reset`]: ./trait.FtdiCommon.html#method.reset
+    /// [`reset`]: FtdiCommon::reset
     pub reset: bool,
     /// USB in transfer size in bytes.
     ///
     /// This gets passed to [`set_usb_parameters`].
     ///
-    /// [`set_usb_parameters`]: ./trait.FtdiCommon.html#method.set_usb_parameters
+    /// [`set_usb_parameters`]: FtdiCommon::set_usb_parameters
     pub in_transfer_size: u32,
     /// Read timeout.
     ///
     /// This gets passed along with [`write_timeout`] to [`set_timeouts`].
     ///
-    /// [`set_timeouts`]: ./trait.FtdiCommon.html#method.set_timeouts
-    /// [`write_timeout`]: #structfield.write_timeout
+    /// [`set_timeouts`]: FtdiCommon::set_timeouts
+    /// [`write_timeout`]: MpsseSettings::write_timeout
     pub read_timeout: Duration,
     /// Write timeout.
     ///
     /// This gets passed along with [`read_timeout`] to [`set_timeouts`].
     ///
-    /// [`set_timeouts`]: ./trait.FtdiCommon.html#method.set_timeouts
-    /// [`read_timeout`]: #structfield.read_timeout
+    /// [`set_timeouts`]: FtdiCommon::set_timeouts
+    /// [`read_timeout`]: MpsseSettings::read_timeout
     pub write_timeout: Duration,
     /// Latency timer.
     ///
     /// This gets passed to [`set_latency_timer`].
     ///
-    /// [`set_latency_timer`]: ./trait.FtdiCommon.html#method.set_latency_timer
+    /// [`set_latency_timer`]: FtdiCommon::set_latency_timer
     pub latency_timer: Duration,
     /// Bitmode mask.
     ///
@@ -398,7 +398,7 @@ pub struct MpsseSettings {
     ///
     /// This gets passed to [`set_bit_mode`].
     ///
-    /// [`set_bit_mode`]: ./trait.FtdiCommon.html#method.set_bit_mode
+    /// [`set_bit_mode`]: FtdiCommon::set_bit_mode
     pub mask: u8,
     /// Clock frequency.
     ///
@@ -499,7 +499,7 @@ pub trait FtdiMpsse: FtdiCommon {
     /// # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
     /// ```
     ///
-    /// [`reset`]: ./trait.FtdiCommon.html#method.reset
+    /// [`reset`]: FtdiCommon::reset
     fn initialize_mpsse(&mut self, settings: &MpsseSettings) -> Result<(), TimeoutError> {
         if settings.reset {
             self.reset()?;
@@ -542,8 +542,7 @@ pub trait FtdiMpsse: FtdiCommon {
     /// # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
     /// ```
     ///
-    /// [`initialize_mpsse`]: #method.initialize_mpsse
-    /// [`MpsseSettings`]: ./struct.MpsseSettings.html
+    /// [`initialize_mpsse`]: FtdiMpsse::initialize_mpsse
     fn initialize_mpsse_default(&mut self) -> Result<(), TimeoutError> {
         self.initialize_mpsse(&MpsseSettings::default())
     }
@@ -678,7 +677,7 @@ pub trait FtdiMpsse: FtdiCommon {
     /// These pins confusingly map to the first four bits in the direction and
     /// state masks.
     ///
-    /// [`set_gpio_lower`]: #method.set_gpio_lower
+    /// [`set_gpio_lower`]: FtdiMpsse::set_gpio_lower
     fn set_gpio_upper(&mut self, state: u8, direction: u8) -> Result<(), TimeoutError> {
         self.write_all(&[MpsseCmd::SetDataBitsHighbyte.into(), state, direction])
     }
@@ -691,8 +690,8 @@ pub trait FtdiMpsse: FtdiCommon {
     /// See [`set_gpio_upper`] for additional information about physical pin
     /// mappings.
     ///
-    /// [`gpio_lower`]: #method.gpio_lower
-    /// [`set_gpio_upper`]: #method.set_gpio_upper
+    /// [`gpio_lower`]: FtdiMpsse::gpio_lower
+    /// [`set_gpio_upper`]: FtdiMpsse::set_gpio_upper
     fn gpio_upper(&mut self) -> Result<u8, TimeoutError> {
         self.write_all(&[
             MpsseCmd::GetDataBitsHighbyte.into(),
@@ -837,7 +836,7 @@ pub trait Ftx232hMpsse: FtdiMpsse {
 /// SPI operations.
 ///
 /// [FTDI MPSSE Basics]: https://www.ftdichip.com/Support/Documents/AppNotes/AN_135_MPSSE_Basics.pdf
-/// [`write_all`]: ./trait.FtdiCommon.html#method.write_all
+/// [`write_all`]: FtdiCommon::write_all
 pub struct MpsseCmdBuilder(pub Vec<u8>);
 
 impl MpsseCmdBuilder {
@@ -1136,7 +1135,7 @@ impl MpsseCmdBuilder {
     /// # Ok::<(), std::boxed::Box<dyn std::error::Error>>(())
     /// ```
     ///
-    /// [`set_gpio_upper`]: #method.set_gpio_upper
+    /// [`set_gpio_upper`]: FtdiMpsse::set_gpio_upper
     pub fn gpio_upper(mut self) -> Self {
         self.0.push(MpsseCmd::GetDataBitsHighbyte.into());
         self

--- a/src/types.rs
+++ b/src/types.rs
@@ -58,7 +58,7 @@ pub const STRING_LEN: usize = 64;
 ///
 /// This is used by the [`set_data_characteristics`] method.
 ///
-/// [`set_data_characteristics`]: ./trait.FtdiCommon.html#method.set_data_characteristics
+/// [`set_data_characteristics`]: crate::FtdiCommon::set_data_characteristics
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(u8)]
 pub enum BitsPerWord {
@@ -84,7 +84,7 @@ impl Default for BitsPerWord {
 ///
 /// This is used by the [`set_data_characteristics`] method.
 ///
-/// [`set_data_characteristics`]: ./trait.FtdiCommon.html#method.set_data_characteristics
+/// [`set_data_characteristics`]: crate::FtdiCommon::set_data_characteristics
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(u8)]
 pub enum StopBits {
@@ -110,7 +110,7 @@ impl Default for StopBits {
 ///
 /// This is used by the [`set_data_characteristics`] method.
 ///
-/// [`set_data_characteristics`]: ./trait.FtdiCommon.html#method.set_data_characteristics
+/// [`set_data_characteristics`]: crate::FtdiCommon::set_data_characteristics
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(u8)]
 pub enum Parity {
@@ -161,8 +161,6 @@ const DEVICE_4222_PROG: u32 = FT_DEVICE_4222_PROG as u32;
 /// which device with the FTD2XX driver.
 ///
 /// This is used in the [`DeviceInfo`] struct.
-///
-/// [`DeviceInfo`]: ./struct.DeviceInfo.html
 #[allow(non_camel_case_types)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(u32)]
@@ -282,8 +280,8 @@ impl From<u32> for DeviceType {
 ///
 /// This is returned by [`library_version`] and [`driver_version`].
 ///
-/// [`library_version`]: ./fn.library_version.html
-/// [`driver_version`]: ./struct.Ftdi.html#method.driver_version
+/// [`library_version`]: crate::library_version
+/// [`driver_version`]: crate::Ftdi::driver_version
 /// [SemVer]: https://semver.org/
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Version {
@@ -408,7 +406,7 @@ impl Version {
 ///
 /// This structure is passed to [`set_bit_mode`] to set the bit mode.
 ///
-/// [`set_bit_mode`]: ./struct.Ftdi.html#method.set_bit_mode
+/// [`set_bit_mode`]: crate::Ftdi::set_bit_mode
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u8)]
 pub enum BitMode {
@@ -465,8 +463,6 @@ fn bit_mode_sanity() {
 /// USB device speed.
 ///
 /// This is used in the [`DeviceInfo`] struct.
-///
-/// [`DeviceInfo`]: ./struct.DeviceInfo.html
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(u8)]
 pub enum Speed {
@@ -566,8 +562,8 @@ impl ModemStatus {
 ///
 /// This is returned by [`list_devices`] and [`device_info`].
 ///
-/// [`list_devices`]: ./fn.list_devices.html
-/// [`device_info`]: ./struct.Ftdi.html#method.device_info
+/// [`list_devices`]: crate::list_devices
+/// [`device_info`]: crate::Ftdi::device_info
 #[derive(Clone, Eq, PartialEq, Default, Ord, PartialOrd)]
 pub struct DeviceInfo {
     /// `true` if the port is open.
@@ -577,7 +573,7 @@ pub struct DeviceInfo {
     /// This will be `None` when getting the information of an open device with
     /// the [`device_info`] function.
     ///
-    /// [`device_info`]: ./struct.Ftdi.html#method.device_info
+    /// [`device_info`]: crate::Ftdi::device_info
     pub speed: Option<Speed>,
     /// FTDI device type.
     pub device_type: DeviceType,


### PR DESCRIPTION
This should help keep the links valid in case of refactors.